### PR TITLE
UefiPayloadPkg/GraphicsOutputDxe: Allow for framebuffer at an offset …

### DIFF
--- a/UefiPayloadPkg/GraphicsOutputDxe/GraphicsOutput.c
+++ b/UefiPayloadPkg/GraphicsOutputDxe/GraphicsOutput.c
@@ -435,8 +435,9 @@ GraphicsOutputDriverBindingStart (
             }
 
             if (DeviceInfo->BarIndex == MAX_UINT8) {
-              if (Resources->AddrRangeMin == GraphicsInfo->FrameBufferBase) {
-                FrameBufferBase = Resources->AddrRangeMin;
+              if (Resources->AddrRangeMin <= GraphicsInfo->FrameBufferBase
+                  && Resources->AddrRangeMin + Resources->AddrLen >= GraphicsInfo->FrameBufferBase + GraphicsInfo->FrameBufferSize ) {
+                FrameBufferBase = GraphicsInfo->FrameBufferBase;
                 break;
               }
             } else {


### PR DESCRIPTION
…from BAR

On Meteor Lake the framebuffer is at BAR2 + 0x800000. Allow for this case when validating the framebuffer info received from coreboot.

Fixes graphics output on Meteor Lake platforms.